### PR TITLE
chore: 增加编辑器规范

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+insert_final_newline = false
+trim_trailing_whitespace = false

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,10 @@
 {
-  "recommendations": ["Vue.volar"]
+  "recommendations": [
+    "Vue.volar",
+    "streetsidesoftware.code-spell-checker",
+    "editorconfig.editorconfig",
+    "stylelint.vscode-stylelint",
+    "esbenp.prettier-vscode",
+    "dbaeumer.vscode-eslint"
+  ]
 }


### PR DESCRIPTION
### 📑 变动性质

- [x] 新特性提交
- [ ] 日常 bug 修复
- [ ] 功能增强
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 工作流程
- [ ] 其他改动（是关于什么的改动？）

### 📌 需求背景和解决方案

编辑器打开项目时自动按照以下规范对本项目设置：

权限 Root

全部：
设置字符集为 UTF-8
换行符为 LF
缩进的大小为 2 个空格
缩进使用空格而不是制表符
每个文件都要有一个换行符结尾也就是最后一行是空的

md：
自动移除每行末尾的多余空格
Markdown 不自动移除每行末尾的多余空格

### ☑️ 请求合并前的自查清单

- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供